### PR TITLE
Add SetDecay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,40 @@ func retryable() {
 
                 log.Printf("error in someOperation: %v", err)
                 <-time.After(b.Duration())
-		}
+        }
 
         log.Printf("succeeded after %d tries", b.Tries()+1)
         b.Reset()
+}
+```
+
+It can also be used to rate limit code that should retry infinitely, but which does not
+use `Backoff` itself.
+
+```
+package something
+
+import (
+    "time"
+
+    "github.com/cloudflare/backoff"
+)
+
+func retryable() {
+        b := backoff.New(0, 0)
+        b.SetDecay(30 * time.Second)
+
+        for {
+                // b will reset if someOperation returns later than
+                // the last call to b.Duration() + 30s.
+                err := someOperation()
+                if err == nil {
+                    break
+                }
+
+                log.Printf("error in someOperation: %v", err)
+                <-time.After(b.Duration())
+        }
 }
 ```
 


### PR DESCRIPTION
SetDecay makes it possible to use backoff with non-cooperating code. Reset does not have to be called explicitly, but is implicitly performed if at least the last backoff duration + decay interval have elapsed since the last try.

This commit takes away the Backoff.Tries() function. I'm not sure the API is meaningful in the context of a Backoff that can reset.
