### PR TITLE
Lock prng when adding jitter

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -25,6 +25,7 @@ import (
 	"time"
 )
 
+var prngMu sync.Mutex
 var prng *mrand.Rand
 
 // DefaultInterval is used when a Backoff is initialised with a
@@ -128,7 +129,9 @@ func (b *Backoff) Duration() time.Duration {
 	}
 
 	if !b.noJitter {
+		prngMu.Lock()
 		t = time.Duration(prng.Int63n(int64(t)))
+		prngMu.Unlock()
 	}
 
 	return t


### PR DESCRIPTION
The default Rand implementation is not concurrency-safe, so we need to lock the source before using it.
