### PR TITLE
Expose number of tries

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -195,3 +195,7 @@ func (b *Backoff) decayN() {
 
 	b.n = 0
 }
+
+func (b *Backoff) Tries() uint64 {
+	return b.n
+}


### PR DESCRIPTION
The README mentions you can call `Backoff.Tries()` to get the number of tries -- this func does not exist. It's also quite convenient if you want to implement a maximum amount of tries. 